### PR TITLE
Fix for generated "The create view is rendered again with the correct model" condition in save

### DIFF
--- a/src/templates/scaffolding/Spec.groovy
+++ b/src/templates/scaffolding/Spec.groovy
@@ -40,7 +40,7 @@ class ${className}ControllerSpec extends Specification {
             controller.save(${propertyName})
 
         then:"The create view is rendered again with the correct model"
-            model.${propertyName}!= null
+            model.${modelName}!= null
             view == 'create'
 
         when:"The save action is executed with a valid instance"


### PR DESCRIPTION
Currently, the generated spec will fail when ran against a domain class called board as follows ( after adding a property to the domain class ):

| Failure:  Test the save action correctly persists an instance(com.kanbanito.BoardControllerSpec)
|  Condition not satisfied:
model.board!= null
|     |    |
|     null false
[boardInstance:com.kanbanito.Board : (unsaved)]

the fix causes the line model.boardInstance to be generated instead of model.board, which then makes the test pass. 
