### PR TITLE
Fixed missing check for instance not found

### DIFF
--- a/src/templates/scaffolding/Controller.groovy
+++ b/src/templates/scaffolding/Controller.groovy
@@ -14,6 +14,11 @@ class ${className}Controller {
     }
 
     def show(${className} ${propertyName}) {
+        if (${propertyName} == null) {
+            notFound()
+            return
+        }
+
         respond ${propertyName}
     }
 


### PR DESCRIPTION
The show method in scaffolded controller code does not check if the instance is found or not
