### PR TITLE
Added support for Restful controllers. Added generate-restful-controller

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,6 @@
 target
 .settings
 web-app
+/.project
+/.classpath
+/target-eclipse

--- a/application.properties
+++ b/application.properties
@@ -1,4 +1,4 @@
 #Grails Metadata file
-#Thu Sep 26 22:03:27 EEST 2013
-app.grails.version=2.3.1.BUILD-SNAPSHOT
+#Fri Dec 13 09:22:32 CST 2013
+app.grails.version=2.3.4
 app.servlet.version=2.5

--- a/grails-app/conf/Config.groovy
+++ b/grails-app/conf/Config.groovy
@@ -9,3 +9,27 @@ log4j = {
 
 // for integration tests
 Metadata.current[Metadata.APPLICATION_NAME] = 'grails-scaffolding'
+
+// Uncomment and edit the following lines to start using Grails encoding & escaping improvements
+
+/* remove this line 
+// GSP settings
+grails {
+    views {
+        gsp {
+            encoding = 'UTF-8'
+            htmlcodec = 'xml' // use xml escaping instead of HTML4 escaping
+            codecs {
+                expression = 'html' // escapes values inside null
+                scriptlet = 'none' // escapes output from scriptlets in GSPs
+                taglib = 'none' // escapes output from taglibs
+                staticparts = 'none' // escapes output from static template parts
+            }
+        }
+        // escapes all not-encoded output at final stage of outputting
+        filteringCodecForContentType {
+            //'text/html' = 'html'
+        }
+    }
+}
+remove this line */

--- a/scripts/GenerateRestfulController.groovy
+++ b/scripts/GenerateRestfulController.groovy
@@ -1,0 +1,56 @@
+/*
+ * Copyright 2004-2013 SpringSource.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Generates CRUD views for a given domain class
+ *
+ * @author Graeme Rocher
+ *
+ * @since 0.4
+ */
+
+includeTargets << new File(scaffoldingPluginDir, 'scripts/_GrailsGenerate.groovy')
+
+target (generateRestfulController: "Generates the Restful controller for a specified domain class") {
+    depends(checkVersion, parseArguments, packageApp)
+
+    promptForName(type: "Domain Class")
+
+    generateViews = false
+    generateController = false
+    generateRestfulController = true
+    generateAsyncController = false
+
+    String name = argsMap['params'][0]
+    if (!name || name == '*') {
+        uberGenerate()
+    }
+    else {
+        generateForName = name
+        generateForOne()
+    }
+}
+
+USAGE = """
+    generate-restful-controller [NAME]
+
+where
+    NAME       = Either a domain class name (case-sensitive) or a
+				 wildcard (*). If you specify the wildcard then
+				 controllers will be generated for all domain classes.
+"""
+
+setDefaultTarget 'generateRestfulController'

--- a/scripts/_GrailsGenerate.groovy
+++ b/scripts/_GrailsGenerate.groovy
@@ -30,6 +30,7 @@ includeTargets << grailsScript("_GrailsCreateArtifacts")
 generateForName = null
 generateViews = true
 generateController = true
+generateRestfulController = false
 generateAsyncController = false
 
 target(generateForOne: "Generates controllers and views for only one domain class.") {
@@ -92,12 +93,16 @@ void generateForDomainClass(domainClass) {
         templateGenerator.generateAsyncTest(domainClass, "${basedir}/test/unit")
         event("GenerateControllerEnd", [domainClass.fullName])
     }
+    else if (generateRestfulController) {
+        event("StatusUpdate", ["Generating controller for domain class ${domainClass.fullName}"])
+        templateGenerator.generateRestfulController(domainClass, basedir)
+        templateGenerator.generateRestfulTest(domainClass, "${basedir}/test/unit")
+        event("GenerateControllerEnd", [domainClass.fullName])
+    }
     else if (generateController) {
 		event("StatusUpdate", ["Generating controller for domain class ${domainClass.fullName}"])
 		templateGenerator.generateController(domainClass, basedir)
 		templateGenerator.generateTest(domainClass, "${basedir}/test/unit")
 		event("GenerateControllerEnd", [domainClass.fullName])
 	}
-
-
 }

--- a/src/java/org/codehaus/groovy/grails/scaffolding/GrailsTemplateGenerator.java
+++ b/src/java/org/codehaus/groovy/grails/scaffolding/GrailsTemplateGenerator.java
@@ -51,6 +51,13 @@ public interface GrailsTemplateGenerator {
 	void generateController(GrailsDomainClass domainClass, String destDir) throws IOException;
 
     /**
+     * Generates a Restful controller for the supplied domain class.
+     * @param domainClass The DomainClass to generate views for
+     * @param destDir The destination directory to generate views to
+     */
+    void generateRestfulController(GrailsDomainClass domainClass, String destDir) throws IOException;
+
+    /**
      * Generates a controller for the supplied domain class.
      * @param domainClass The DomainClass to generate views for
      * @param destDir The destination directory to generate views to
@@ -91,7 +98,27 @@ public interface GrailsTemplateGenerator {
 	 */
 	void generateController(GrailsDomainClass domainClass, Writer out) throws IOException;
 
+    /**
+     * Generates a controller unit test for the specified domain class.
+     *
+     * @param domainClass The domain class
+     * @param destDir The destination
+     */
 	void generateTest(GrailsDomainClass domainClass, String destDir) throws IOException;
 
+    /**
+     * Generates a controller unit test for the specified domain class.
+     *
+     * @param domainClass The domain class
+     * @param destDir The destination
+     */
+    void generateRestfulTest(GrailsDomainClass domainClass, String destDir) throws IOException;
+    
+    /**
+     * Generates a controller unit test for the specified domain class.
+     *
+     * @param domainClass The domain class
+     * @param destDir The destination
+     */
     void generateAsyncTest(GrailsDomainClass domainClass, String destDir) throws IOException;
 }

--- a/src/templates/scaffolding/RestfulController.groovy
+++ b/src/templates/scaffolding/RestfulController.groovy
@@ -1,0 +1,62 @@
+<%=packageName ? "package ${packageName}\n\n" : ''%>
+
+import static org.springframework.http.HttpStatus.*
+import grails.transaction.Transactional
+
+@Transactional(readOnly = true)
+class ${className}Controller {
+    
+    static responseFormats = ['json', 'xml']
+    static allowedMethods = [save: "POST", update: "PUT", delete: "DELETE"]
+
+    def index(Integer max) {
+        params.max = Math.min(max ?: 10, 100)
+        respond ${className}.list(params), [status: OK]
+    }
+
+    @Transactional
+    def save(${className} ${propertyName}) {
+        if (${propertyName} == null) {
+            render status: NOT_FOUND
+            return
+        }
+
+        ${propertyName}.validate()
+        if (${propertyName}.hasErrors()) {
+            render status: NOT_ACCEPTABLE
+            return
+        }
+
+        ${propertyName}.save flush:true
+        respond ${propertyName}, [status: CREATED]
+    }
+
+    @Transactional
+    def update(${className} ${propertyName}) {
+        if (${propertyName} == null) {
+            render status: NOT_FOUND
+            return
+        }
+
+        ${propertyName}.validate()
+        if (${propertyName}.hasErrors()) {
+            render status: NOT_ACCEPTABLE
+            return
+        }
+
+        ${propertyName}.save flush:true
+        respond ${propertyName}, [status: OK]
+    }
+
+    @Transactional
+    def delete(${className} ${propertyName}) {
+
+        if (${propertyName} == null) {
+            render status: NOT_FOUND
+            return
+        }
+
+        ${propertyName}.delete flush:true
+        render status: NO_CONTENT
+    }
+}

--- a/src/templates/scaffolding/RestfulSpec.groovy
+++ b/src/templates/scaffolding/RestfulSpec.groovy
@@ -1,0 +1,99 @@
+<%=packageName ? "package ${packageName}\n\n" : ''%>
+
+import static org.springframework.http.HttpStatus.*
+import grails.converters.JSON
+import grails.test.mixin.*
+import spock.lang.*
+
+@TestFor(${className}Controller)
+@Mock(${className})
+class ${className}ControllerSpec extends Specification {
+
+    def populateValidParams(params) {
+        assert params != null
+        // TODO: Populate valid properties like...
+        //params['name'] = 'someValidName'
+    }
+
+    void "Test the index action returns the correct model"() {
+
+        when:"The index action is executed"
+            controller.index()
+
+        then:"The response is correct"
+            response.status == OK.value
+            response.text == ([] as JSON).toString()
+    }
+
+    void "Test the save action correctly persists an instance"() {
+
+        when:"The save action is executed with an invalid instance"
+            // Make sure the domain class has at least one non-null property
+            // or this test will fail.
+            def ${propertyName} = new ${className}()
+            controller.save(${propertyName})
+
+        then:"The response status is NOT_ACCEPTABLE"
+            response.status == NOT_ACCEPTABLE.value
+
+        when:"The save action is executed with a valid instance"
+            response.reset()
+            populateValidParams(params)
+            ${propertyName} = new ${className}(params)
+
+            controller.save(${propertyName})
+
+        then:"The response status is CREATED and the instance is returned"
+            response.status == CREATED.value
+            response.text == (${propertyName} as JSON).toString()
+    }
+
+    void "Test the update action performs an update on a valid domain instance"() {
+        when:"Update is called for a domain instance that doesn't exist"
+            controller.update(null)
+
+        then:"The response status is NOT_FOUND"
+            response.status == NOT_FOUND.value
+
+        when:"An invalid domain instance is passed to the update action"
+            response.reset()
+            def ${propertyName} = new ${className}()
+            controller.update(${propertyName})
+
+        then:"The response status is NOT_ACCEPTABLE"
+            response.status == NOT_ACCEPTABLE.value
+
+        when:"A valid domain instance is passed to the update action"
+            response.reset()
+            populateValidParams(params)
+            ${propertyName} = new ${className}(params).save(flush: true)
+            controller.update(${propertyName})
+
+        then:"The response status is OK and the updated instance is returned"
+            response.status == OK.value
+            response.text == (${propertyName} as JSON).toString()
+    }
+
+    void "Test that the delete action deletes an instance if it exists"() {
+        when:"The delete action is called for a null instance"
+            controller.delete(null)
+
+        then:"A NOT_FOUND is returned"
+            response.status == NOT_FOUND.value
+
+        when:"A domain instance is created"
+            response.reset()
+            populateValidParams(params)
+            def ${propertyName} = new ${className}(params).save(flush: true)
+
+        then:"It exists"
+            ${className}.count() == 1
+
+        when:"The domain instance is passed to the delete action"
+            controller.delete(${propertyName})
+
+        then:"The instance is deleted"
+            ${className}.count() == 0
+            response.status == NO_CONTENT.value
+    }
+}


### PR DESCRIPTION
This command will create a restful controller and unit test. This means:
1) Assumes the UrlMapping for the domain class follows the restful pattern: "/domains"(resources:'domain')
2) Assumes the allowed Methods are: [index: "GET", save: "POST", update: "PUT", delete: "DELETE"]
2) Supports only JSON and XML responses.
