### PR TITLE
Ignore properties with display : false

### DIFF
--- a/src/templates/scaffolding/_form.gsp
+++ b/src/templates/scaffolding/_form.gsp
@@ -10,7 +10,7 @@
 			persistentPropNames << domainClass.identifier.name
 		}
 	}
-	props = domainClass.properties.findAll { persistentPropNames.contains(it.name) && !excludedProps.contains(it.name) }
+	props = domainClass.properties.findAll { persistentPropNames.contains(it.name) && !excludedProps.contains(it.name) && (domainClass.constrainedProperties[it.name] ? domainClass.constrainedProperties[it.name].display : true) }
 	Collections.sort(props, comparator.constructors[0].newInstance([domainClass] as Object[]))
 	for (p in props) {
 		if (p.embedded) {

--- a/src/templates/scaffolding/index.gsp
+++ b/src/templates/scaffolding/index.gsp
@@ -25,7 +25,7 @@
 					<tr>
 					<%  excludedProps = Event.allEvents.toList() << 'id' << 'version'
 						allowedNames = domainClass.persistentProperties*.name << 'dateCreated' << 'lastUpdated'
-						props = domainClass.properties.findAll { allowedNames.contains(it.name) && !excludedProps.contains(it.name) && it.type != null && !Collection.isAssignableFrom(it.type) }
+						props = domainClass.properties.findAll { allowedNames.contains(it.name) && !excludedProps.contains(it.name) && it.type != null && !Collection.isAssignableFrom(it.type) && (domainClass.constrainedProperties[it.name] ? domainClass.constrainedProperties[it.name].display : true) }
 						Collections.sort(props, comparator.constructors[0].newInstance([domainClass] as Object[]))
 						props.eachWithIndex { p, i ->
 							if (i < 6) {

--- a/src/templates/scaffolding/show.gsp
+++ b/src/templates/scaffolding/show.gsp
@@ -24,7 +24,7 @@
 			<ol class="property-list ${domainClass.propertyName}">
 			<%  excludedProps = Event.allEvents.toList() << 'id' << 'version'
 				allowedNames = domainClass.persistentProperties*.name << 'dateCreated' << 'lastUpdated'
-				props = domainClass.properties.findAll { allowedNames.contains(it.name) && !excludedProps.contains(it.name) }
+				props = domainClass.properties.findAll { allowedNames.contains(it.name) && !excludedProps.contains(it.name) && (domainClass.constrainedProperties[it.name] ? domainClass.constrainedProperties[it.name].display : true) }
 				Collections.sort(props, comparator.constructors[0].newInstance([domainClass] as Object[]))
 				props.each { p -> %>
 				<g:if test="\${${propertyName}?.${p.name}}">


### PR DESCRIPTION
There is an issue for scaffolding displaying domain properties with constraint _display_ set to _false_.
Works for regular and _embedded_ properties.
