### PR TITLE
Treats String properties as required only if not nullable.

### DIFF
--- a/src/templates/scaffolding/_form.gsp
+++ b/src/templates/scaffolding/_form.gsp
@@ -34,7 +34,7 @@ private renderFieldForProperty(p, owningClass, prefix = "") {
 	if (hasHibernate) {
 		cp = owningClass.constrainedProperties[p.name]
 		display = (cp ? cp.display : true)
-		required = (cp ? !(cp.propertyType in [boolean, Boolean]) && !cp.nullable && (cp.propertyType != String || !cp.blank) : false)
+		required = (cp ? !(cp.propertyType in [boolean, Boolean]) && !cp.nullable : false)
 	}
 	if (display) { %>
 <div class="fieldcontain \${hasErrors(bean: ${propertyName}, field: '${prefix}${p.name}', 'error')} ${required ? 'required' : ''}">

--- a/src/templates/scaffolding/renderEditor.template
+++ b/src/templates/scaffolding/renderEditor.template
@@ -267,7 +267,7 @@
 	        return false
 	    }
 	    else {
-	        cp.nullable || (cp.propertyType == String && cp.blank) || cp.propertyType in [boolean, Boolean]
+	        cp.nullable || cp.propertyType in [boolean, Boolean]
 	    }
 	}
 %>


### PR DESCRIPTION
This results in a more consistent behavior since grails trims String-Inputs by default in current versions.

@see http://goo.gl/iylAvL
