### PR TITLE
honor the generated/scaffolded method restrictions in the controller

### DIFF
--- a/src/templates/scaffolding/Spec.groovy
+++ b/src/templates/scaffolding/Spec.groovy
@@ -35,6 +35,7 @@ class ${className}ControllerSpec extends Specification {
 
         when:"The save action is executed with an invalid instance"
             request.contentType = FORM_CONTENT_TYPE
+            request.method = 'POST'
             def ${propertyName} = new ${className}()
             ${propertyName}.validate()
             controller.save(${propertyName})
@@ -91,6 +92,7 @@ class ${className}ControllerSpec extends Specification {
     void "Test the update action performs an update on a valid domain instance"() {
         when:"Update is called for a domain instance that doesn't exist"
             request.contentType = FORM_CONTENT_TYPE
+            request.method = 'PUT'
             controller.update(null)
 
         then:"A 404 error is returned"
@@ -122,6 +124,7 @@ class ${className}ControllerSpec extends Specification {
     void "Test that the delete action deletes an instance if it exists"() {
         when:"The delete action is called for a null instance"
             request.contentType = FORM_CONTENT_TYPE
+            request.method = 'DELETE'
             controller.delete(null)
 
         then:"A 404 is returned"


### PR DESCRIPTION
The generated controller has HTTP method restrictions which prevent the generated spec tests from working 'out of the box'.
