### PR TITLE
GPSCAFFOLD-96: (Dynamic Scaffolding) Make hard limit of 6 properties in index.gsp configurable

### DIFF
--- a/src/java/org/codehaus/groovy/grails/scaffolding/AbstractGrailsTemplateGenerator.java
+++ b/src/java/org/codehaus/groovy/grails/scaffolding/AbstractGrailsTemplateGenerator.java
@@ -162,6 +162,7 @@ public abstract class AbstractGrailsTemplateGenerator implements GrailsTemplateG
 		binding.put("packageName", packageName);
 		binding.put("multiPart", multiPart);
 		binding.put("propertyName", getPropertyName(domainClass));
+		binding.put("grailsApplication", grailsApplication);
 
 		generate(templateText, binding, out);
 	}

--- a/src/templates/scaffolding/index.gsp
+++ b/src/templates/scaffolding/index.gsp
@@ -28,7 +28,7 @@
 						props = domainClass.properties.findAll { allowedNames.contains(it.name) && !excludedProps.contains(it.name) && it.type != null && !Collection.isAssignableFrom(it.type) && (domainClass.constrainedProperties[it.name] ? domainClass.constrainedProperties[it.name].display : true) }
 						Collections.sort(props, comparator.constructors[0].newInstance([domainClass] as Object[]))
 						props.eachWithIndex { p, i ->
-							if (i < 6) {
+							if (i < (grailsApplication.config?.grails?.plugin?.scaffolding?.properties?.max?.toString().isNumber() ? grailsApplication.config?.grails?.plugin?.scaffolding?.properties?.max : 6)) {
 								if (p.isAssociation()) { %>
 						<th><g:message code="${domainClass.propertyName}.${p.name}.label" default="${p.naturalName}" /></th>
 					<%      } else { %>
@@ -42,7 +42,7 @@
 					<%  props.eachWithIndex { p, i ->
 							if (i == 0) { %>
 						<td><g:link action="show" id="\${${propertyName}.id}">\${fieldValue(bean: ${propertyName}, field: "${p.name}")}</g:link></td>
-					<%      } else if (i < 6) {
+					<%      } else if (i < (grailsApplication.config?.grails?.plugin?.scaffolding?.properties?.max?.toString().isNumber() ? grailsApplication.config?.grails?.plugin?.scaffolding?.properties?.max : 6)) {
 								if (p.type == Boolean || p.type == boolean) { %>
 						<td><g:formatBoolean boolean="\${${propertyName}.${p.name}}" /></td>
 					<%          } else if (p.type == Date || p.type == java.sql.Date || p.type == java.sql.Time || p.type == Calendar) { %>


### PR DESCRIPTION
Currently the template of the `index.gsp` contains a hard limit of maximum `6` domain properties. This is not very flexible since I as developer cannot change the behaviour.

This hard limit would furthermore force me to `install-templates` which is not what I want just to tweak this small configuration. This pull request contains a simple improvement and give the developer the freedom to override the hard limit of `6` by adding this statement `grails.plugin.scaffolding.properties.max = 20` to the `Config.groovy`.
