### PR TITLE
informative msg for static scaffold=true

### DIFF
--- a/ScaffoldingGrailsPlugin.groovy
+++ b/ScaffoldingGrailsPlugin.groovy
@@ -126,8 +126,9 @@ class ScaffoldingGrailsPlugin {
 		GrailsDomainClass domainClass = getScaffoldedDomainClass(application, controllerClass, scaffoldProperty)
 		scaffoldedActionMap[controllerClass.logicalPropertyName] = []
 		if (!domainClass) {
-			log.error "Cannot generate controller logic for scaffolded class {}. It is not a domain class!", scaffoldProperty
-			return
+		    scaffoldProperty = (scaffoldProperty == true) ? controllerClass.logicalPropertyName.capitalize() : scaffoldProperty
+		    log.error "Cannot generate controller logic for scaffolded class {} in controller {}. It is not a domain class!", scaffoldProperty, controllerClass.fullName
+  			return
 		}
 
 		GrailsTemplateGenerator generator = ctx.scaffoldingTemplateGenerator


### PR DESCRIPTION
More informative message when static scaffold=true form is used in sacfolded Controller. 
Modification causes the expected domain class name as well as the controller name when domain class is not found.

---

package vgd
class BookController {
    static scaffold=true
## }

Original msg:
| Error 2014-10-20 14:53:56,290 [localhost-startStop-1] ERROR ScaffoldingGrailsPlugin  - Cannot generate controller logic for scaffolded class true. It is not a domain class!

Proposed msg example:
| Error 2014-10-20 15:44:41,580 [localhost-startStop-1] ERROR ScaffoldingGrailsPlugin  - Cannot generate controller logic for scaffolded class Book in controller vgd.BookController. It is not a domain class!
