### PR TITLE
Support Custom Template Generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -17,3 +17,4 @@ stacktrace.log
 /target-eclipse/
 .classpath
 .project
+*.iml

--- a/ScaffoldingGrailsPlugin.groovy
+++ b/ScaffoldingGrailsPlugin.groovy
@@ -13,6 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+
+import grails.util.Holders
+
 import java.lang.reflect.Method
 import java.lang.reflect.Modifier
 import java.util.concurrent.ConcurrentHashMap
@@ -64,9 +67,16 @@ class ScaffoldingGrailsPlugin {
 
 		controllerToScaffoldedDomainClassMap(ConcurrentHashMap)
 
-		scaffoldingTemplateGenerator(DefaultGrailsTemplateGenerator, ref("classLoader")) {
-			grailsApplication = ref("grailsApplication")
-		}
+        def customGeneratorClass = Holders.config.grails.plugin.scaffolding.customTemplateGenerator
+        if (customGeneratorClass) {
+            scaffoldingTemplateGenerator(customGeneratorClass, ref("classLoader")) {
+                grailsApplication = ref("grailsApplication")
+            }
+        } else {
+            scaffoldingTemplateGenerator(DefaultGrailsTemplateGenerator, ref("classLoader")) {
+                grailsApplication = ref("grailsApplication")
+            }
+        }
 
 		jspViewResolver(ScaffoldingViewResolver) { bean ->
 			bean.lazyInit = true

--- a/application.properties
+++ b/application.properties
@@ -1,1 +1,3 @@
-app.grails.version=2.4.5.BUILD-SNAPSHOT
+#Grails Metadata file
+#Fri Apr 03 20:54:47 CDT 2015
+app.grails.version=2.5.0

--- a/grails-app/conf/BuildConfig.groovy
+++ b/grails-app/conf/BuildConfig.groovy
@@ -12,7 +12,7 @@ grails.project.dependency.resolution = {
 	}
 
     dependencies {
-        test "org.grails:grails-datastore-gorm-hibernate:3.0.5.RELEASE"
+        test "org.grails:grails-datastore-gorm-hibernate:3.1.4.RELEASE"
     }
 
 	plugins {

--- a/scripts/_GrailsGenerate.groovy
+++ b/scripts/_GrailsGenerate.groovy
@@ -15,6 +15,7 @@
  */
 
 import grails.util.GrailsNameUtils
+import grails.util.Holders
 
 /**
  * Generates a CRUD controller and matching views for a given domain class
@@ -76,9 +77,12 @@ target(uberGenerate: "Generates controllers and views for all domain classes.") 
 }
 
 void generateForDomainClass(domainClass) {
-	def DefaultGrailsTemplateGenerator = classLoader.loadClass('org.codehaus.groovy.grails.scaffolding.DefaultGrailsTemplateGenerator')
+    def templateGeneratorClass = Holders.config.grails.plugin.scaffolding.customTemplateGenerator
+    if (! templateGeneratorClass) {
+        templateGeneratorClass = classLoader.loadClass('org.codehaus.groovy.grails.scaffolding.DefaultGrailsTemplateGenerator')
+    }
 
-	def templateGenerator = DefaultGrailsTemplateGenerator.newInstance(classLoader)
+	def templateGenerator = templateGeneratorClass.newInstance(classLoader)
 	templateGenerator.grailsApplication = grailsApp
 	templateGenerator.pluginManager = pluginManager
 	if (generateViews) {

--- a/src/templates/scaffolding/_form.gsp
+++ b/src/templates/scaffolding/_form.gsp
@@ -19,12 +19,12 @@
 			Collections.sort(embeddedProps, comparator.constructors[0].newInstance([p.component] as Object[]))
 			%><fieldset class="embedded"><legend><g:message code="${domainClass.propertyName}.${p.name}.label" default="${p.naturalName}" /></legend><%
 				for (ep in p.component.properties) {
-					if (ep.name != 'id') {
+					if (ep.name != 'id' && ! (Collection.class.isAssignableFrom(ep.type) && ! ep.referencedDomainClass)) {
 						renderFieldForProperty(ep, p.component, "${p.name}.")
 					}
 				}
 			%></fieldset><%
-		} else {
+        } else {
 			renderFieldForProperty(p, domainClass)
 		}
 	}


### PR DESCRIPTION
- Support Custom Template Generators (in both dynamic and generated templates)
- Ignore embedded many to many relationships in scaffolded forms (database structure doesn’t support this)
- Upgrade GORM dependency
- Set Grails version to 2.5.0
- Ignore IntelliJ files